### PR TITLE
Fix hardcoded value in helper method

### DIFF
--- a/uaa_bot/bot.py
+++ b/uaa_bot/bot.py
@@ -24,7 +24,7 @@ class UAABot:
         users = []
         uaac = UAAClient(uaa_config=self.uaa_config)
         uaac.authenticate()
-        response = uaac.list_expiring_users(days_ago=90, days_range=1)
+        response = uaac.list_expiring_users(days_ago=days_ago)
         resources = response.get("resources")
 
         # Deactivate and send notification of account deactivation


### PR DESCRIPTION
Fix the bot query for 10 days and 1 day till deactivation query to NOT be the hardcoded 90 days. (same as deactivation). Closes #3 

## Changes proposed in this pull request:
- Remove hard coded 90 day to use the variable for 80 and 89 day notifications

## security considerations
none