### PR TITLE
Add iaas tag so resource check has permissions to read file

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -423,6 +423,8 @@ resources:
     region_name: ((uaa-bot-region))
     regexp: (.*)summary(.*).json
     server_side_encryption: AES256
+  tags:
+  - iaas
 
 - name: general-task
   type: registry-image


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add iaas tag so the resource has iam permissions to read the dashboard team's bucket
- Part of https://github.com/cloud-gov/private/issues/1879
-

## security considerations
Only adds tag for which concourse worker to use for running the container
