### PR TITLE
Add last login staging stub

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -370,15 +370,40 @@ jobs:
       channel: ((slack-info-channel))
       username: ((slack-username))
       icon_url: ((slack-icon-url))
-  on_success:
+
+
+
+- name: bot-staging-list-lastlogon
+  plan:
+#  - get: daily-timer
+#    trigger: true
+  - get: general-task
+  - get: src-repository
+    resource: src-repository
+    passed: [test-bot, bot-development-list-lastlogon]
+  - task: run-bot-staging-list-lastlogon
+    image: general-task
+    file: src-repository/ci/run-bot-command-no-date.yml
+    params:
+      BUILD_JOB_NAME: staging-list-lastlogon
+      BOT_COMMAND: list-last-logon -d 0 -r 365
+      UAA_BASE_URL: ((uaa-base-url-staging))
+      UAA_CLIENT_ID: ((uaa-client-id-staging))
+      UAA_CLIENT_SECRET: ((uaa-client-secret-staging))
+  - put: staging-dashboard-bucket
+    tags: [iaas]
+    params:
+      file: uaa-bot-summary/*-summary*.json
+  on_failure:
     put: slack
     params:
       text: |
-        :white_check_mark: Successfully listed last logon for users in development with uaa-bot
+        :x: FAILED to list last logon for users in staging with uaa-bot
         <$ATC_EXTERNAL_URL/teams/$BUILD_TEAM_NAME/pipelines/$BUILD_PIPELINE_NAME/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME|View build details>
       channel: ((slack-info-channel))
       username: ((slack-username))
       icon_url: ((slack-icon-url))
+
 
 ###########
 # Resources
@@ -419,12 +444,24 @@ resources:
   type: s3-iam
   icon: database
   source:
-    bucket: ((dashboard-bucket-development))
+    bucket: ((dashboard-bucket-development))  # Provided by the Dashboard team
     region_name: ((uaa-bot-region))
     regexp: (.*)summary(.*).json
     server_side_encryption: AES256
   tags:
   - iaas
+
+- name: staging-dashboard-bucket
+  type: s3-iam
+  icon: database
+  source:
+    bucket: ((dashboard-bucket-staging))  # Provided by the Dashboard team
+    region_name: ((uaa-bot-region))
+    regexp: (.*)summary(.*).json
+    server_side_encryption: AES256
+  tags:
+  - iaas
+
 
 - name: general-task
   type: registry-image


### PR DESCRIPTION
## Changes proposed in this pull request:
- Add staging creation of logon file to the pipeline.  Using an s3 bucket service instance from my cf space until the Dashboard team has created one and provided it.  
- Removed "on success" notifications for logon jobs to reduce noise in the slack channel
- Have the timer resource commented out initially so it can be observed to run.
- Left a note on the resource that the s3 bucket needs to be provided, platform doesn't create it, hopefully saving the next engineer the time of hunting through Terraform to realize it isn't created with our automation.

## security considerations
Client credentials, bucket ids and urls stored in credhub
