### PR TITLE
Turn timer back on

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -375,8 +375,8 @@ jobs:
 
 - name: bot-staging-list-lastlogon
   plan:
-#  - get: daily-timer
-#    trigger: true
+  - get: daily-timer
+    trigger: true
   - get: general-task
   - get: src-repository
     resource: src-repository


### PR DESCRIPTION
## Changes proposed in this pull request:
- Now that staging was deployed and tested, turning the timer back on for new job from https://github.com/cloud-gov/uaa-bot/pull/35
- Part of https://github.com/cloud-gov/private/issues/1879
-

## Security considerations
None, turning a timer resource back on for a new job task
